### PR TITLE
fix(serial): disable software flow control

### DIFF
--- a/libs/esp_flasher/src/esp_flasher.cpp
+++ b/libs/esp_flasher/src/esp_flasher.cpp
@@ -263,7 +263,7 @@ QSerialPort::SerialPortError EspFlasher::open(QString port, QString baud) {
   if (!_serial->setDataBits(QSerialPort::Data8)) return _serial->error();
   if (!_serial->setStopBits(QSerialPort::OneStop)) return _serial->error();
   if (!_serial->setParity(QSerialPort::NoParity)) return _serial->error();
-  if (!_serial->setFlowControl(QSerialPort::SoftwareControl))
+  if (!_serial->setFlowControl(QSerialPort::NoFlowControl))
     return _serial->error();
 
   auto fd{_serial->handle()};


### PR DESCRIPTION
## Summary
- Disable Qt software flow control so binary ESP serial protocol bytes are not consumed as XON/XOFF control bytes.
- Match the raw/no-flow-control behavior used by esp-serial-flasher's Linux port.

## Test plan
- Built Debug target with CMake/Ninja.
- Flashed a 4 KiB generated test image to ESP32-C6 on /dev/ttyUSB0 and confirmed SPI_FLASH_MD5 and FLASH_END completed successfully in trace output.